### PR TITLE
[userscript] Fix loading of user stats from gym page

### DIFF
--- a/userscripts/tornium-estimate.user.js
+++ b/userscripts/tornium-estimate.user.js
@@ -337,18 +337,33 @@ async function getOneStat(tid) {
                 // Example inner text
                 // Strength\n111,111,111\n\nDamage you make on impact\n\nUnavailable\n\nTRAIN
 
-                console.log(mutation.addedNodes[0].innerText);
-                console.log(mutation.addedNodes[0].innerText.startsWith("STR"));
-                console.log(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", ""));
-
-                if (mutation.addedNodes[0].innerText.startsWith("Strength") || mutation.addedNodes[0].innerText.startsWith("STR")) {
+                if (mutation.addedNodes[0].innerText.startsWith("Strength")) {
                     statScore += Math.sqrt(Number(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", "")));
-                } else if (mutation.addedNodes[0].innerText.startsWith("Defense") || mutation.addedNodes[0].innerText.startsWith("DEF")) {
+                } else if (mutation.addedNodes[0].innerText.startsWith("STR")) {
+                    statScore += Math.sqrt(
+                        Number(mutation.addedNodes[0].innerText.split("\n")[0].substring(3).replaceAll(",", "")),
+                    );
+                } else if (mutation.addedNodes[0].innerText.startsWith("Defense")) {
                     statScore += Math.sqrt(Number(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", "")));
-                } else if (mutation.addedNodes[0].innerText.startsWith("Speed") || mutation.addedNodes[0].innerText.startsWith("SPD")) {
+                } else if (mutation.addedNodes[0].innerText.startsWith("DEF")) {
+                    statScore += Math.sqrt(
+                        Number(mutation.addedNodes[0].innerText.split("\n")[0].substring(3).replaceAll(",", "")),
+                    );
+                } else if (mutation.addedNodes[0].innerText.startsWith("Speed")) {
                     statScore += Math.sqrt(Number(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", "")));
-                } else if (mutation.addedNodes[0].innerText.startsWith("Dexterity") || mutation.addedNodes[0].innerText.startsWith("DEX")) {
+                } else if (mutation.addedNodes[0].innerText.startsWith("SPD")) {
+                    statScore += Math.sqrt(
+                        Number(mutation.addedNodes[0].innerText.split("\n")[0].substring(3).replaceAll(",", "")),
+                    );
+                } else if (mutation.addedNodes[0].innerText.startsWith("Dexterity")) {
                     statScore += Math.sqrt(Number(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", "")));
+                    GM_setValue("tornium-estimate:user:bs", statScore);
+                    observer.disconnect();
+                    return;
+                } else if (mutation.addedNodes[0].innerText.startsWith("DEX")) {
+                    statScore += Math.sqrt(
+                        Number(mutation.addedNodes[0].innerText.split("\n")[0].substring(3).replaceAll(",", "")),
+                    );
                     GM_setValue("tornium-estimate:user:bs", statScore);
                     observer.disconnect();
                     return;

--- a/userscripts/tornium-estimate.user.js
+++ b/userscripts/tornium-estimate.user.js
@@ -16,8 +16,8 @@
 // @grant        GM_deleteValue
 // @grant        GM_addStyle
 // @connect      tornium.com
-// @downloadURL  https://github.com/Tornium/tornium/blob/dev/estimate-userscript/userscripts/tornium-estimate.user.js
-// @updateURL    https://github.com/Tornium/tornium/blob/dev/estimate-userscript/userscripts/tornium-estimate.user.js
+// @downloadURL  https://github.com/Tornium/tornium/raw/refs/heads/dev/estimate-userscript/userscripts/tornium-estimate.user.js
+// @updateURL    https://github.com/Tornium/tornium/raw/refs/heads/dev/estimate-userscript/userscripts/tornium-estimate.user.js
 // @supportURL   https://discord.gg/pPcqTRTRyF
 // ==/UserScript==
 

--- a/userscripts/tornium-estimate.user.js
+++ b/userscripts/tornium-estimate.user.js
@@ -337,6 +337,10 @@ async function getOneStat(tid) {
                 // Example inner text
                 // Strength\n111,111,111\n\nDamage you make on impact\n\nUnavailable\n\nTRAIN
 
+                console.log(mutation.addedNodes[0].innerText);
+                console.log(mutation.addedNodes[0].innerText.startsWith("STR"));
+                console.log(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", ""));
+
                 if (mutation.addedNodes[0].innerText.startsWith("Strength") || mutation.addedNodes[0].innerText.startsWith("STR")) {
                     statScore += Math.sqrt(Number(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", "")));
                 } else if (mutation.addedNodes[0].innerText.startsWith("Defense") || mutation.addedNodes[0].innerText.startsWith("DEF")) {

--- a/userscripts/tornium-estimate.user.js
+++ b/userscripts/tornium-estimate.user.js
@@ -53,6 +53,7 @@ const TIME_UNITS = {
 };
 
 // Code taken from https://stackoverflow.com/a/11381730/12941872
+// biome-ignore format: This function isn't readable anyways
 window.mobileCheck = function() {
   let check = false;
   (function(a){if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4))) check = true;})(navigator.userAgent||navigator.vendor||window.opera);
@@ -68,9 +69,13 @@ const accessTokenExpiration = GM_getValue("tornium-estimate:access-token-expires
 const userStatScore = GM_getValue("tornium-estimate:user:bs", null);
 
 if (window.mobileCheck()) {
-    GM_addStyle(".tornium-estimate-inline {font-size: 12px; display: inline-block; right: 0px; position: absolute; padding-right: 40px;}");
+    GM_addStyle(
+        ".tornium-estimate-inline {font-size: 12px; display: inline-block; right: 0px; position: absolute; padding-right: 40px;}",
+    );
 } else {
-    GM_addStyle(".tornium-estimate-inline {font-size: 12px; display: inline-block; right: 0px; position: absolute; padding-right: 15px;}");
+    GM_addStyle(
+        ".tornium-estimate-inline {font-size: 12px; display: inline-block; right: 0px; position: absolute; padding-right: 15px;}",
+    );
 }
 
 function arrayToString(array) {
@@ -332,13 +337,13 @@ async function getOneStat(tid) {
                 // Example inner text
                 // Strength\n111,111,111\n\nDamage you make on impact\n\nUnavailable\n\nTRAIN
 
-                if (mutation.addedNodes[0].innerText.startsWith("Strength")) {
+                if (mutation.addedNodes[0].innerText.startsWith("Strength") || mutation.addedNodes[0].innerText.startsWith("STR")) {
                     statScore += Math.sqrt(Number(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", "")));
-                } else if (mutation.addedNodes[0].innerText.startsWith("Defense")) {
+                } else if (mutation.addedNodes[0].innerText.startsWith("Defense") || mutation.addedNodes[0].innerText.startsWith("DEF")) {
                     statScore += Math.sqrt(Number(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", "")));
-                } else if (mutation.addedNodes[0].innerText.startsWith("Speed")) {
+                } else if (mutation.addedNodes[0].innerText.startsWith("Speed") || mutation.addedNodes[0].innerText.startsWith("SPD")) {
                     statScore += Math.sqrt(Number(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", "")));
-                } else if (mutation.addedNodes[0].innerText.startsWith("Dexterity")) {
+                } else if (mutation.addedNodes[0].innerText.startsWith("Dexterity") || mutation.addedNodes[0].innerText.startsWith("DEX")) {
                     statScore += Math.sqrt(Number(mutation.addedNodes[0].innerText.split("\n")[1].replaceAll(",", "")));
                     GM_setValue("tornium-estimate:user:bs", statScore);
                     observer.disconnect();
@@ -398,7 +403,9 @@ async function getOneStat(tid) {
                     }
 
                     const userContainer = addedNode.getElementsByClassName("expander")[0];
-                    const userID = new URLSearchParams(new URL(userContainer.getElementsByClassName("user name")[0].href).search).get("XID");
+                    const userID = new URLSearchParams(
+                        new URL(userContainer.getElementsByClassName("user name")[0].href).search,
+                    ).get("XID");
 
                     let span = document.createElement("p");
                     span.classList = ["tornium-estimate-inline"];
@@ -418,11 +425,14 @@ async function getOneStat(tid) {
                         } else {
                             $(`#tornium-estimate-${userID}`).text("ERR");
                         }
-
                     });
                 }
             }
         });
-        observer.observe(document.getElementsByClassName("user-info-list-wrap")[0], { attributes: false, childList: true, subtree: true });
+        observer.observe(document.getElementsByClassName("user-info-list-wrap")[0], {
+            attributes: false,
+            childList: true,
+            subtree: true,
+        });
     }
 })();

--- a/userscripts/tornium-estimate.user.js
+++ b/userscripts/tornium-estimate.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tornium Estimation
 // @namespace    https://tornium.com
-// @version      0.3.7
+// @version      0.3.8-1
 // @copyright    GPLv3
 // @author       tiksan [2383326]
 // @match        https://www.torn.com/profiles.php*

--- a/userscripts/tornium-estimate.user.js
+++ b/userscripts/tornium-estimate.user.js
@@ -16,8 +16,8 @@
 // @grant        GM_deleteValue
 // @grant        GM_addStyle
 // @connect      tornium.com
-// @downloadURL  https://github.com/Tornium/tornium/raw/refs/heads/master/userscripts/tornium-estimate.user.js
-// @updateURL    https://github.com/Tornium/tornium/raw/refs/heads/master/userscripts/tornium-estimate.user.js
+// @downloadURL  https://github.com/Tornium/tornium/blob/dev/estimate-userscript/userscripts/tornium-estimate.user.js
+// @updateURL    https://github.com/Tornium/tornium/blob/dev/estimate-userscript/userscripts/tornium-estimate.user.js
 // @supportURL   https://discord.gg/pPcqTRTRyF
 // ==/UserScript==
 

--- a/userscripts/tornium-estimate.user.js
+++ b/userscripts/tornium-estimate.user.js
@@ -16,8 +16,8 @@
 // @grant        GM_deleteValue
 // @grant        GM_addStyle
 // @connect      tornium.com
-// @downloadURL  https://github.com/Tornium/tornium/raw/refs/heads/dev/estimate-userscript/userscripts/tornium-estimate.user.js
-// @updateURL    https://github.com/Tornium/tornium/raw/refs/heads/dev/estimate-userscript/userscripts/tornium-estimate.user.js
+// @downloadURL  https://github.com/Tornium/tornium/raw/refs/heads/master/userscripts/tornium-estimate.user.js
+// @updateURL    https://github.com/Tornium/tornium/raw/refs/heads/master/userscripts/tornium-estimate.user.js
 // @supportURL   https://discord.gg/pPcqTRTRyF
 // ==/UserScript==
 


### PR DESCRIPTION
On smaller devices (such as the iPhone 13 mini), the gym page would show `DEF<stats>` instead of `Defense\n<stats>` breaking the parsing and calculations required for stat score used in FF calculations.