### PR TITLE
Fix issue for Tornium#247: Cancelled vault request doesn't retain ID

### DIFF
--- a/application/skynet/commands/faction/cancel.py
+++ b/application/skynet/commands/faction/cancel.py
@@ -228,7 +228,7 @@ def cancel_command(interaction, *args, **kwargs):
         {
             "embeds": [
                 {
-                    "title": f"Vault Request #{withdrawal_id}",
+                    "title": f"Vault Request #{withdrawal.wid}",
                     "description": f"This request has been cancelled by {discord_escaper(user.name)} [{user.tid}].",
                     "fields": [
                         {


### PR DESCRIPTION
This pull request includes a minor update to the `cancel_command` function in the `application/skynet/commands/faction/cancel.py` file. 

The change updates the `title` field to use the `wid` attribute of the `withdrawal` object instead of the `withdrawal_id` variable, fixing the issue referenced at the original repository where the Discord embed didn't retain the withdrawal ID from the request.

### File(s) Affected

* [`application/skynet/commands/faction/cancel.py`](diffhunk://#diff-5fcbe7670f0767378b0d8ff85984100e89448a15338439d30ba847438977c59fL231-R231): Updated the `title` field in the embed dictionary to reference `withdrawal.wid` instead of `withdrawal_id` for consistency with the `withdrawal` object.